### PR TITLE
News CRUD를 구현한다.

### DIFF
--- a/src/news/dto/return-news-collection.dto.ts
+++ b/src/news/dto/return-news-collection.dto.ts
@@ -1,0 +1,9 @@
+import { ReturnNewsDto } from "./return-news.dto";
+
+export class ReturnNewsDtoCollection {
+  constructor(returnNewsDtoList: ReturnNewsDto[]) {
+    this.returnNewsDtoCollection = returnNewsDtoList;
+  }
+
+  returnNewsDtoCollection: ReturnNewsDto[] | [];
+}

--- a/src/news/dto/return-news.dto.ts
+++ b/src/news/dto/return-news.dto.ts
@@ -1,0 +1,36 @@
+import { Time } from "src/module/Time";
+import { Category } from "../common/Category";
+import { Channel } from "../common/Channel";
+import { Gender } from "../common/Gender";
+import { Suitability } from "../common/Suitability";
+import { News } from "../news.entity";
+
+export class ReturnNewsDto {
+  constructor(news: News) {
+    this.title = news.title;
+    this.category = news.category;
+    this.script = news.script;
+    this.announcerGender = news.announcerGender;
+    this.channel = news.channel;
+    this.link = news.link;
+    this.thumbnail = news.thumbnail;
+    this.startTime = news.startTime;
+    this.endTime = news.endTime;
+    this.suitability = news.suitability;
+    this.isEmbeddable = news.isEmbeddable;
+    this.reportDate = news.reportDate;
+}
+
+    title: string;
+    category: Category;
+    script: string;
+    announcerGender: Gender;
+    channel: Channel;
+    link: string;
+    thumbnail: string;
+    startTime: number;
+    endTime: number;
+    suitability: Suitability;
+    isEmbeddable: boolean;
+    reportDate: Date;
+}

--- a/src/news/dto/update-news.dto.ts
+++ b/src/news/dto/update-news.dto.ts
@@ -1,0 +1,20 @@
+import { Time } from "src/module/Time";
+import { Category } from "../common/Category";
+import { Channel } from "../common/Channel";
+import { Gender } from "../common/Gender";
+import { Suitability } from "../common/Suitability";
+
+export class UpdateNewsDto {
+    title: string;
+    category: Category;
+    script: string;
+    announcerGender: Gender;
+    channel: Channel;
+    link: string;
+    thumbnail: string;
+    startTime: number;
+    endTime: number;
+    suitability: Suitability;
+    isEmbeddable: boolean;
+    reportDate: Date;
+}

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { CreateNewsDto } from './dto/create-news.dto';
 import { News } from './news.entity';
 import { NewsService } from './news.service';
@@ -12,5 +12,10 @@ export class NewsController {
         @Body() createNewsDto: CreateNewsDto
         ): Promise<News | void> {
 		return this.newsService.createNews(createNewsDto);
+	}
+
+    @Get('all')
+	getAllNews(): Promise<News[] | void> {
+		return this.newsService.getAllNews();
 	}
 }

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -1,5 +1,7 @@
 import { Body, Controller, Delete, Get, Logger, Param, Post } from '@nestjs/common';
 import { CreateNewsDto } from './dto/create-news.dto';
+import { ReturnNewsDtoCollection } from './dto/return-news-collection.dto';
+import { ReturnNewsDto } from './dto/return-news.dto';
 import { UpdateNewsDto } from './dto/update-news.dto';
 import { News } from './news.entity';
 import { NewsService } from './news.service';
@@ -13,12 +15,12 @@ export class NewsController {
     @Post('create')
 	createNews(
         @Body() createNewsDto: CreateNewsDto
-        ): Promise<News[] | void> {
+        ): Promise<ReturnNewsDtoCollection> {            
 		return this.newsService.createAndGetAllNews(createNewsDto);
 	}
 
     @Get('all')
-	getAllNews(): Promise<News[] | void> {
+	getAllNews(): Promise<ReturnNewsDtoCollection> {
 		return this.newsService.getAllNews();
 	}
 
@@ -26,14 +28,14 @@ export class NewsController {
 	updateNews(
     @Body() updateNewsDto: UpdateNewsDto,
     @Param('id') id : number
-    ): Promise<News[] | void> {
+    ): Promise<ReturnNewsDtoCollection> {
         return this.newsService.updateAndGetAllNews(id, updateNewsDto);
 	}
 
     @Delete('delete/:id')
 	deleteNews(
     @Param('id') id : number
-    ): Promise<News[] | void> {
+    ): Promise<ReturnNewsDtoCollection> {
         return this.newsService.deleteAndGetAllNews(id);
 	}
 }

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -1,7 +1,10 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Logger, Param, Post } from '@nestjs/common';
 import { CreateNewsDto } from './dto/create-news.dto';
+import { UpdateNewsDto } from './dto/update-news.dto';
 import { News } from './news.entity';
 import { NewsService } from './news.service';
+
+const logger: Logger = new Logger('news controller');
 
 @Controller('news')
 export class NewsController {
@@ -17,5 +20,13 @@ export class NewsController {
     @Get('all')
 	getAllNews(): Promise<News[] | void> {
 		return this.newsService.getAllNews();
+	}
+
+    @Post('update/:id')
+	updateNews(
+    @Body() updateNewsDto: UpdateNewsDto,
+    @Param('id') id : number
+    ): Promise<News[] | void> {
+        return this.newsService.updateAndGetAllNews(id, updateNewsDto);
 	}
 }

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Logger, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Logger, Param, Post } from '@nestjs/common';
 import { CreateNewsDto } from './dto/create-news.dto';
 import { UpdateNewsDto } from './dto/update-news.dto';
 import { News } from './news.entity';
@@ -28,5 +28,12 @@ export class NewsController {
     @Param('id') id : number
     ): Promise<News[] | void> {
         return this.newsService.updateAndGetAllNews(id, updateNewsDto);
+	}
+
+    @Delete('delete/:id')
+	deleteNews(
+    @Param('id') id : number
+    ): Promise<News[] | void> {
+        return this.newsService.deleteAndGetAllNews(id);
 	}
 }

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -13,8 +13,8 @@ export class NewsController {
     @Post('create')
 	createNews(
         @Body() createNewsDto: CreateNewsDto
-        ): Promise<News | void> {
-		return this.newsService.createNews(createNewsDto);
+        ): Promise<News[] | void> {
+		return this.newsService.createAndGetAllNews(createNewsDto);
 	}
 
     @Get('all')

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -1,5 +1,7 @@
 import { EntityRepository, Repository, UpdateResult } from "typeorm";
 import { CreateNewsDto } from "./dto/create-news.dto";
+import { ReturnNewsDtoCollection } from "./dto/return-news-collection.dto";
+import { ReturnNewsDto } from "./dto/return-news.dto";
 import { UpdateNewsDto } from "./dto/update-news.dto";
 import { News } from "./news.entity";
 
@@ -23,17 +25,24 @@ export class NewsRepository extends Repository<News> {
         return news;
     }
 
-    async getAllNews(): Promise<News[]> {
-        return await this.find();
+    async getAllNews(): Promise<ReturnNewsDtoCollection> {
+        const newsList: News[] = await this.find();
+        const returnNewsDtoList: ReturnNewsDto[] = newsList.map(
+            (news: News) => new ReturnNewsDto(news)
+            )
+        const returnNewsDtoCollection: ReturnNewsDtoCollection = new ReturnNewsDtoCollection(returnNewsDtoList)
+        return returnNewsDtoCollection;
     }
 
-    async getNewsById(id: number): Promise<News> {
-        return await this.findOne({
+    async getNewsById(id: number): Promise<ReturnNewsDto> {
+        const news: News = await this.findOne({
             id: id
         })
+        const returnNewsDto: ReturnNewsDto = new ReturnNewsDto(news);
+        return returnNewsDto
     }
 
-    async updateNews(id: number, updateNewsDto: UpdateNewsDto): Promise<News | void> {
+    async updateNews(id: number, updateNewsDto: UpdateNewsDto): Promise<ReturnNewsDto> {
         await this.update(
             { id: id },
                 updateNewsDto
@@ -41,8 +50,8 @@ export class NewsRepository extends Repository<News> {
         return await this.getNewsById(id);
     }
 
-    async deleteNews(id: number): Promise<News | void> {
-        const news: News = await this.getNewsById(id);
+    async deleteNews(id: number): Promise<ReturnNewsDto> {
+        const news: ReturnNewsDto = await this.getNewsById(id);
         await this.delete(
             { id: id }
         )

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -22,4 +22,8 @@ export class NewsRepository extends Repository<News> {
         return news;
     }
 
+    async getAllNews(): Promise<News[]> {
+        return await this.find();
+    }
+
 }

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -38,8 +38,15 @@ export class NewsRepository extends Repository<News> {
             { id: id },
                 updateNewsDto
             )
-        
         return await this.getNewsById(id);
+    }
+
+    async deleteNews(id: number): Promise<News | void> {
+        const news: News = await this.getNewsById(id);
+        await this.delete(
+            { id: id }
+        )
+        return news;
     }
 
 }

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -1,5 +1,6 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, Repository, UpdateResult } from "typeorm";
 import { CreateNewsDto } from "./dto/create-news.dto";
+import { UpdateNewsDto } from "./dto/update-news.dto";
 import { News } from "./news.entity";
 
 @EntityRepository(News)
@@ -24,6 +25,21 @@ export class NewsRepository extends Repository<News> {
 
     async getAllNews(): Promise<News[]> {
         return await this.find();
+    }
+
+    async getNewsById(id: number): Promise<News> {
+        return await this.findOne({
+            id: id
+        })
+    }
+
+    async updateNews(id: number, updateNewsDto: UpdateNewsDto): Promise<News | void> {
+        await this.update(
+            { id: id },
+                updateNewsDto
+            )
+        
+        return await this.getNewsById(id);
     }
 
 }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -1,8 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { UpdateResult } from 'typeorm';
 import { CreateNewsDto } from './dto/create-news.dto';
+import { UpdateNewsDto } from './dto/update-news.dto';
 import { News } from './news.entity';
 import { NewsRepository } from './news.repository';
+
+const logger: Logger = new Logger('news service');
 
 @Injectable()
 export class NewsService {
@@ -18,4 +22,15 @@ export class NewsService {
     async getAllNews() : Promise<News[] | void> {
 		return await this.newsRepository.getAllNews();
 	}
+
+    async updateNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News | void> {
+        
+        const updateResult: News | void = await this.newsRepository.updateNews(id, updateNewsDto);
+        return updateResult;
+    }
+
+    async updateAndGetAllNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News[] | void> {
+        await this.updateNews(id, updateNewsDto);
+        return await this.getAllNews();
+    }
 }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UpdateResult } from 'typeorm';
 import { CreateNewsDto } from './dto/create-news.dto';
+import { ReturnNewsDtoCollection } from './dto/return-news-collection.dto';
+import { ReturnNewsDto } from './dto/return-news.dto';
 import { UpdateNewsDto } from './dto/update-news.dto';
 import { News } from './news.entity';
 import { NewsRepository } from './news.repository';
@@ -19,31 +21,31 @@ export class NewsService {
 		return await this.newsRepository.createNews(createNewsDto);
 	}
 
-    async getAllNews() : Promise<News[] | void> {
+    async getAllNews() : Promise<ReturnNewsDtoCollection> {
 		return await this.newsRepository.getAllNews();
 	}
 
-    async updateNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News | void> {
-        const updateResult: News | void = await this.newsRepository.updateNews(id, updateNewsDto);
+    async updateNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<ReturnNewsDto> {
+        const updateResult: ReturnNewsDto = await this.newsRepository.updateNews(id, updateNewsDto);
         return updateResult;
     }
 
-    async deleteNews(id: number) : Promise<News | void> {
-        const deleteResult: News | void = await this.newsRepository.deleteNews(id);
+    async deleteNews(id: number) : Promise<ReturnNewsDto> {
+        const deleteResult: ReturnNewsDto = await this.newsRepository.deleteNews(id);
         return deleteResult;
     }
 
-    async createAndGetAllNews(createNewsDto: CreateNewsDto) : Promise<News[] | void> {
+    async createAndGetAllNews(createNewsDto: CreateNewsDto) : Promise<ReturnNewsDtoCollection> {
         await this.createNews(createNewsDto);
         return await this.getAllNews();
     }
 
-    async updateAndGetAllNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News[] | void> {
+    async updateAndGetAllNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<ReturnNewsDtoCollection> {
         await this.updateNews(id, updateNewsDto);
         return await this.getAllNews();
     }
 
-    async deleteAndGetAllNews(id: number) : Promise<News[] | void> {
+    async deleteAndGetAllNews(id: number) : Promise<ReturnNewsDtoCollection> {
         await this.deleteNews(id);
         return await this.getAllNews();
     }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -24,13 +24,22 @@ export class NewsService {
 	}
 
     async updateNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News | void> {
-        
         const updateResult: News | void = await this.newsRepository.updateNews(id, updateNewsDto);
         return updateResult;
     }
 
+    async deleteNews(id: number) : Promise<News | void> {
+        const deleteResult: News | void = await this.newsRepository.deleteNews(id);
+        return deleteResult;
+    }
+
     async updateAndGetAllNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News[] | void> {
         await this.updateNews(id, updateNewsDto);
+        return await this.getAllNews();
+    }
+
+    async deleteAndGetAllNews(id: number) : Promise<News[] | void> {
+        await this.deleteNews(id);
         return await this.getAllNews();
     }
 }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -14,4 +14,8 @@ export class NewsService {
     async createNews(createNewsDto: CreateNewsDto) : Promise<News | void> {
 		return await this.newsRepository.createNews(createNewsDto);
 	}
+
+    async getAllNews() : Promise<News[] | void> {
+		return await this.newsRepository.getAllNews();
+	}
 }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -33,6 +33,11 @@ export class NewsService {
         return deleteResult;
     }
 
+    async createAndGetAllNews(createNewsDto: CreateNewsDto) : Promise<News[] | void> {
+        await this.createNews(createNewsDto);
+        return await this.getAllNews();
+    }
+
     async updateAndGetAllNews(id: number, updateNewsDto: UpdateNewsDto) : Promise<News[] | void> {
         await this.updateNews(id, updateNewsDto);
         return await this.getAllNews();

--- a/src/user/dto/return-user.dto.ts
+++ b/src/user/dto/return-user.dto.ts
@@ -1,7 +1,7 @@
 import { Social } from "src/auth/common/Social";
 import { Gender } from "src/news/common/Gender";
 
-export class UserInfo {
+export class ReturnUserDto {
   id: number;
   socialId: string;
   nickname: string;

--- a/src/user/dto/user-for-view.dto.ts
+++ b/src/user/dto/user-for-view.dto.ts
@@ -1,4 +1,4 @@
-export class UserInfoForView {
+export class UserForViewDto {
   constructor(_nickname: string, _email: string) {
     this.nickname = _nickname;
     this.email = _email;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/auth.guard';
 import { User } from 'src/auth/user.entity';
-import { UserInfoForView } from './dto/user-info-for-view.dto';
-import { UserInfo } from './dto/user-info.dto';
+import { UserForViewDto } from './dto/user-for-view.dto';
+import { ReturnUserDto } from './dto/return-user.dto';
 import { UserService } from './user.service';
 
 @Controller('user')
@@ -11,8 +11,8 @@ export class UserController {
 
   @Get('')
   @UseGuards(JwtAuthGuard)
-  async getUserInfo(@Req() req): Promise<UserInfoForView> {
-    const userInfo: UserInfo = req.user;
+  async getUserInfo(@Req() req): Promise<UserForViewDto> {
+    const userInfo: ReturnUserDto = req.user;
     return this.userService.getUserInfo(userInfo);
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,16 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { UserInfoForView } from './dto/user-info-for-view.dto';
-import { UserInfo } from './dto/user-info.dto';
+import { UserForViewDto } from './dto/user-for-view.dto';
+import { ReturnUserDto } from './dto/return-user.dto';
 
 const logger = new Logger('user.service');
 
 @Injectable()
 export class UserService {
-  // async createNews(createNewsDto: CreateNewsDto) : Promise<News | void> {
-	// 	return await this.newsRepository.createNews(createNewsDto);
-	// }
-  async getUserInfo(userInfo: UserInfo): Promise<UserInfoForView> {
-    const userInfoForView = new UserInfoForView(
+  async getUserInfo(userInfo: ReturnUserDto): Promise<UserForViewDto> {
+    const userInfoForView = new UserForViewDto(
       userInfo.nickname,
       userInfo.email
       );


### PR DESCRIPTION
close #16 

- news/create 구현
- news/all 구현 -> 전체 뉴스 조회
- news/update 구현 -> 특정 id의 뉴스 수정
- news/delete 구현 -> 특정 id의 뉴스 삭제

** 4가지 API 모두 전체 뉴스를 조회한 결과를 반환하도록 구현했습니다.