### PR TITLE
뉴스의 태그 관련 로직을 구현한다. 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeORMConfig } from './configs/typeorm.config';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
+import { TagModule } from './tag/tag.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { UserModule } from './user/user.module';
     NewsModule,
     AuthModule,
     UserModule,
+    TagModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -65,13 +65,13 @@ export class AuthController {
 		try {
 			const jwt = await this.authService.kakaoAuthentication(code);
 			res.setHeader('Authorization', 'Bearer ' + jwt['accessToken']);
+			
 			return res
 				.status(statusCode.OK)
 				.send(util.success(statusCode.OK, message.AUTHENTICATION_SUCCESS, jwt))
 
 		} catch (error) {
 			logger.error(error);
-			console.log("error response >>>>>>", error.response);
 			if (error.response.statusCode === statusCode.UNAUTHORIZED) {
 				return res
 					.status(statusCode.UNAUTHORIZED)

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -27,6 +27,7 @@ export const message = {
   SEARCH_NEWS_SUCCESS: '영상 검색 결과 조회 성공',
   RECOMMEND_NEWS_SUCCESS: '추천 영상 조회 성공',
   DETAIL_NEWS_SUCCESS: '영상 조회 성공',
+  ADD_TAG_TO_NEWS_SUCCESS: '뉴스 태그 추가 성공',
 
   // 태그
   CREATE_TAG_SUCCESS: '태그 생성 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -28,4 +28,9 @@ export const message = {
   RECOMMEND_NEWS_SUCCESS: '추천 영상 조회 성공',
   DETAIL_NEWS_SUCCESS: '영상 조회 성공',
 
+  // 태그
+  CREATE_TAG_SUCCESS: '태그 생성 성공',
+  READ_ALL_TAGS_SUCCESS: '모든 태그 조회 성공',
+  DELETE_TAG_SUCCESS: '태그 삭제 성공',
+
 }

--- a/src/news/dto/return-news.dto.ts
+++ b/src/news/dto/return-news.dto.ts
@@ -1,4 +1,5 @@
 import { Time } from "src/modules/Time";
+import { Tag } from "src/tag/tag.entity";
 import { Category } from "../common/category.enum";
 import { Channel } from "../common/channel.enum";
 import { Gender } from "../common/gender.enum";
@@ -20,6 +21,8 @@ export class ReturnNewsDto {
     this.suitability = news.suitability;
     this.isEmbeddable = news.isEmbeddable;
     this.reportDate = news.reportDate;
+    this.tagsForView = news.tagsForView;
+    this.tagsForRecommend = news.tagsForRecommend;
 }
     id: number;
     title: string;
@@ -34,4 +37,6 @@ export class ReturnNewsDto {
     suitability: Suitability;
     isEmbeddable: boolean;
     reportDate: Date;
+    tagsForView?: Tag[];
+    tagsForRecommend?: Tag[];
 }

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -129,7 +129,6 @@ export class NewsController {
         .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
     }
   }
-
   
 }
 

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -99,6 +99,28 @@ export class NewsController {
     }
   }
 
+  @Post('tag/add/:newsId')
+  async addTagsToNews(
+    @Req() req,
+    @Res() res,
+    @Param('newsId') newsId : number,
+  ): Promise<Response> {
+    try {
+      const tagListForView: string[] = req.body.tagListForView;
+      const tagListForRecommend: string[] = req.body.tagListForRecommend;
+      const data: ReturnNewsDto = await this.newsService.addTagsToNews(newsId, tagListForView, tagListForRecommend)
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.ADD_TAG_TO_NEWS_SUCCESS, data))
+    
+      } catch (error) {
+      logger.error(error)
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+
 
   @Get('search')
 	async searchNews(

--- a/src/news/news.entity.ts
+++ b/src/news/news.entity.ts
@@ -1,7 +1,8 @@
 import { Time } from "src/modules/Time";
+import { Tag } from "src/tag/tag.entity";
 // import { Favorite } from "src/user/favorite.entity";
 import { User } from "src/user/user.entity";
-import { BaseEntity, Column, Entity, ManyToMany, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { BaseEntity, Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { Category } from "./common/category.enum";
 import { Channel } from "./common/channel.enum";
 import { Gender } from "./common/gender.enum";
@@ -99,4 +100,16 @@ export class News extends BaseEntity {
 
     @ManyToMany(() => User, (user) => user.favorites)
     favorites: User[]
+
+    @ManyToMany(() => Tag, (tag) => tag.forView, {
+        eager: true,
+    })
+    @JoinTable()
+    tagsForView: Tag[];
+
+    @ManyToMany(() => Tag, (tag) => tag.forRecommend, {
+        eager: true,
+    })
+    @JoinTable()
+    tagsForRecommend: Tag[];
 }

--- a/src/news/news.module.ts
+++ b/src/news/news.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
+import { TagRepository } from 'src/tag/tag.repository';
 import { NewsController } from './news.controller';
 import { NewsRepository } from './news.repository';
 import { NewsService } from './news.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([NewsRepository]),
+    TypeOrmModule.forFeature([NewsRepository, TagRepository]),
     AuthModule,
   ],
   controllers: [NewsController],

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -1,3 +1,4 @@
+import { Tag } from "src/tag/tag.entity";
 import { EntityRepository, Repository, UpdateResult } from "typeorm";
 import { SearchCondition } from "./common/search-condition";
 import { CreateNewsDto } from "./dto/create-news.dto";
@@ -31,12 +32,34 @@ export class NewsRepository extends Repository<News> {
         return await this.find();
     }
 
-    async getNewsById(id: number): Promise<ReturnNewsDto> {
+    async getNewsById(id: number): Promise<News> {
         const news: News = await this.findOne({
             id: id
         })
-        const returnNewsDto: ReturnNewsDto = new ReturnNewsDto(news);
-        return returnNewsDto
+        return news;
+    }
+
+    async resetTagsOfNews(news: News): Promise<News> {
+        news.tagsForView = [];
+        news.tagsForRecommend = [];
+        news.save();
+        return news;
+    }
+
+    async addTagsForViewToNews(news: News, tagsForView: Tag[]): Promise<News> {
+        tagsForView.forEach((tag) => { 
+            news.tagsForView.push(tag);
+        })
+        news.save();
+        return news;
+    }
+
+    async addTagsForRecommendToNews(news: News, tagsForRecommend: Tag[]): Promise<News> {
+        tagsForRecommend.forEach((tag) => { 
+            news.tagsForRecommend.push(tag);
+        })
+        news.save();
+        return news;
     }
 
     async updateNews(id: number, updateNewsDto: UpdateNewsDto): Promise<ReturnNewsDto> {

--- a/src/news/news.service.spec.ts
+++ b/src/news/news.service.spec.ts
@@ -1,10 +1,10 @@
 import { JwtModule } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
-import { Category } from './common/Category';
-import { Channel } from './common/Channel';
-import { Gender } from './common/Gender';
-import { Suitability } from './common/Suitability';
+import { Category } from './common/category.enum';
+import { Channel } from './common/channel.enum';
+import { Gender } from './common/gender.enum';
+import { Suitability } from './common/suitability.enum';
 import { CreateNewsDto } from './dto/create-news.dto';
 import { ReturnNewsDto } from './dto/return-news.dto';
 import { UpdateNewsDto } from './dto/update-news.dto';

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -83,18 +83,12 @@ export class NewsService {
     const tagsForRecommend: Tag[] = await this.tagRepository.getTagsByNameList(tagListForRecommend);
     const news: News = await this.newsRepository.getNewsById(newsId);
     // 해당 뉴스의 태그(화면 표시용) 초기화
-    console.log("news before reset:", news);
     await this.newsRepository.resetTagsOfNews(news);
     // 태그 추가
-    console.log("news after reset:", news);
     await this.newsRepository.addTagsForViewToNews(news, tagsForView);
-    console.log("news after add tags for view:", news);
     await this.newsRepository.addTagsForRecommendToNews(news, tagsForRecommend);
-    console.log("news after add tags for recommend:", news);
     // 뉴스 불러오기
     const newsAfterAddTags: News = await this.newsRepository.getNewsById(newsId);
-    console.log("news after load:", news);
-    console.log(newsAfterAddTags);
     const returnNewsDto: ReturnNewsDto = new ReturnNewsDto(newsAfterAddTags);
     return returnNewsDto;
   }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -22,6 +22,8 @@ import { VerifiedCallback } from 'passport-jwt';
 import { Payload } from 'src/auth/dto/payload';
 import { ExploreNewsDtoCollection } from './dto/explore-news-collection.dto';
 import { changeToExploreNewsList } from './utils/change-explore-news-list-to-dto';
+import { Tag } from 'src/tag/tag.entity';
+import { TagRepository } from 'src/tag/tag.repository';
 
 const logger: Logger = new Logger('news service');
 
@@ -30,6 +32,8 @@ export class NewsService {
   constructor(
     @InjectRepository(NewsRepository)
     private newsRepository: NewsRepository,
+    @InjectRepository(TagRepository)
+    private tagRepository: TagRepository,
     private authService: AuthService,
   ) {};
 
@@ -67,6 +71,32 @@ export class NewsService {
   async deleteAndGetAllNews(id: number) : Promise<ReturnNewsDtoCollection> {
     await this.deleteNews(id);
     return await this.getAllNews();
+  }
+
+  async addTagsToNews(
+    newsId: number,
+    tagListForView: string[],
+    tagListForRecommend: string[]
+  ): Promise<ReturnNewsDto> {
+    // 태그, 뉴스 불러오기
+    const tagsForView: Tag[] = await this.tagRepository.getTagsByNameList(tagListForView);
+    const tagsForRecommend: Tag[] = await this.tagRepository.getTagsByNameList(tagListForRecommend);
+    const news: News = await this.newsRepository.getNewsById(newsId);
+    // 해당 뉴스의 태그(화면 표시용) 초기화
+    console.log("news before reset:", news);
+    await this.newsRepository.resetTagsOfNews(news);
+    // 태그 추가
+    console.log("news after reset:", news);
+    await this.newsRepository.addTagsForViewToNews(news, tagsForView);
+    console.log("news after add tags for view:", news);
+    await this.newsRepository.addTagsForRecommendToNews(news, tagsForRecommend);
+    console.log("news after add tags for recommend:", news);
+    // 뉴스 불러오기
+    const newsAfterAddTags: News = await this.newsRepository.getNewsById(newsId);
+    console.log("news after load:", news);
+    console.log(newsAfterAddTags);
+    const returnNewsDto: ReturnNewsDto = new ReturnNewsDto(newsAfterAddTags);
+    return returnNewsDto;
   }
 
   async filterNewsByCategory(newsList: News[], searchCondition: SearchCondition) {

--- a/src/tag/dto/create-tag.dto.ts
+++ b/src/tag/dto/create-tag.dto.ts
@@ -1,0 +1,6 @@
+import { Category } from "src/news/common/category.enum";
+
+export class CreateTagDto {
+  name: string;
+  category: Category;
+}

--- a/src/tag/dto/return-tag-collection.dto.ts
+++ b/src/tag/dto/return-tag-collection.dto.ts
@@ -1,0 +1,9 @@
+import { ReturnTagDto } from "./return-tag.dto";
+
+export class ReturnTagDtoCollection {
+  constructor(returnTagDtoList: ReturnTagDto[]) {
+    this.returnTagDtoCollection = returnTagDtoList;
+  }
+
+  returnTagDtoCollection: ReturnTagDto[] | [];
+}

--- a/src/tag/dto/return-tag.dto.ts
+++ b/src/tag/dto/return-tag.dto.ts
@@ -1,0 +1,13 @@
+import { Category } from "src/news/common/category.enum";
+import { Tag } from "../tag.entity";
+
+export class ReturnTagDto {
+  constructor(tag: Tag) {
+    this.id = tag.id;
+    this.name = tag.name;
+    this.category = tag.category;
+  }
+  id: number;
+  name: string;
+  category: Category;
+}

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Logger, Param, Post, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Logger, Param, Post, Req, Res } from '@nestjs/common';
 import { message } from 'src/modules/response/response.message';
 import { statusCode } from 'src/modules/response/response.status.code';
 import { util } from 'src/modules/response/response.util';
@@ -53,10 +53,11 @@ export class TagController {
 
   @Delete('delete/:tagName')
   async deleteTag(
-    @Param('tagName') tagName : string,
+    @Req() req,
     @Res() res
   ): Promise<Response> {
     try {
+      const tagName: string = req.body.tagName;
       const data: ReturnTagDto = await this.tagService.deleteTag(tagName);
       return res
         .status(statusCode.OK)
@@ -74,4 +75,5 @@ export class TagController {
         .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
     }
   }
+
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -1,0 +1,77 @@
+import { Body, Controller, Delete, Get, Logger, Param, Post, Res } from '@nestjs/common';
+import { message } from 'src/modules/response/response.message';
+import { statusCode } from 'src/modules/response/response.status.code';
+import { util } from 'src/modules/response/response.util';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { ReturnTagDtoCollection } from './dto/return-tag-collection.dto';
+import { ReturnTagDto } from './dto/return-tag.dto';
+import { Tag } from './tag.entity';
+import { TagService } from './tag.service';
+
+const logger: Logger = new Logger('tag controller');
+
+@Controller('tag')
+export class TagController {
+  constructor(private tagService: TagService) {};
+
+  @Post('create')
+	async createTag(
+    @Body() createTagDto: CreateTagDto,
+    @Res() res
+    ): Promise<Response> {            
+    try {
+      const data: ReturnTagDto = await this.tagService.createTag(createTagDto);
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.CREATE_TAG_SUCCESS, data))
+    
+      } catch (error) {
+      logger.error(error)
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+
+  @Get('get/all')
+  async getAllTags(
+    @Res() res
+  ): Promise<Response> {
+    try {
+      const data: ReturnTagDtoCollection = await this.tagService.getAllTags();
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.READ_ALL_TAGS_SUCCESS, data))
+    
+      } catch (error) {
+      logger.error(error)
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+
+  @Delete('delete/:tagName')
+  async deleteTag(
+    @Param('tagName') tagName : string,
+    @Res() res
+  ): Promise<Response> {
+    try {
+      const data: ReturnTagDto = await this.tagService.deleteTag(tagName);
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.DELETE_TAG_SUCCESS, data))
+    
+      } catch (error) {
+      logger.error(error)
+			if (error.response.statusCode === statusCode.BAD_REQUEST) {
+				return res
+					.status(statusCode.BAD_REQUEST)
+					.send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST))
+			}
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+}

--- a/src/tag/tag.entity.ts
+++ b/src/tag/tag.entity.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { News } from "src/news/news.entity";
+import { BaseEntity, Column, Entity, ManyToMany, PrimaryGeneratedColumn } from "typeorm";
 import { Category } from "../news/common/category.enum";
 
 @Entity()
@@ -25,5 +26,11 @@ export class Tag extends BaseEntity {
   default: Category.UNSPECIFIED,
   })
   category: Category;
+
+  @ManyToMany(() => News, (news) => news.tagsForView)
+  forView: News[];
+
+  @ManyToMany(() => News, (news) => news.tagsForRecommend)
+  forRecommend: News[];
 
 }

--- a/src/tag/tag.entity.ts
+++ b/src/tag/tag.entity.ts
@@ -1,0 +1,29 @@
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Category } from "../news/common/category.enum";
+
+@Entity()
+export class Tag extends BaseEntity {
+  constructor(
+      _name: string,
+      _category: Category,
+      ) {
+      super();
+      this.name = _name;
+      this.category = _category;
+      }
+      
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 100, unique: true })
+  name: string;
+
+  @Column({
+  type: 'enum',
+  name: 'category',
+  enum: Category,
+  default: Category.UNSPECIFIED,
+  })
+  category: Category;
+
+}

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TagController } from './tag.controller';
+import { TagRepository } from './tag.repository';
+import { TagService } from './tag.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([TagRepository]),
+  ],
+  controllers: [TagController],
+  providers: [TagService]
+})
+export class TagModule {}

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -20,22 +20,28 @@ export class TagRepository extends Repository<Tag> {
     return tag;
 }
 
-async getTagByName(tagName: string): Promise<ReturnTagDto> {
+async getTagByName(tagName: string): Promise<Tag> {
   const tag: Tag = await this.findOne({
     name: tagName
   })
   if (tag === undefined) {
     throw new BadRequestException;
   }
-  const returnTagDto: ReturnTagDto = new ReturnTagDto(tag);
-  return returnTagDto;
-}
-
-async deleteTag(tagName: string): Promise<ReturnTagDto> {
-  const tag: ReturnTagDto = await this.getTagByName(tagName);
-  await this.delete(
-      { name: tagName }
-  )
   return tag;
 }
+
+async getTagsByNameList(tagList: string[]): Promise<Tag[]> {
+  return await this.createQueryBuilder('tag')
+    .where('tag.name IN (:...tagList)', { tagList })
+    .getMany();
+};
+
+async deleteTag(tagName: string): Promise<ReturnTagDto> {
+    const tag: Tag = await this.getTagByName(tagName);
+    const returnTagDto: ReturnTagDto = new ReturnTagDto(tag);
+    await this.delete(
+      { name: tagName }
+    )
+    return returnTagDto;
+    }
 }

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -1,0 +1,41 @@
+import { BadRequestException } from "@nestjs/common";
+import { EntityRepository, Repository } from "typeorm";
+import { CreateTagDto } from "./dto/create-tag.dto";
+import { ReturnTagDto } from "./dto/return-tag.dto";
+import { Tag } from "./tag.entity";
+
+@EntityRepository(Tag)
+export class TagRepository extends Repository<Tag> {
+  async createTag(createTagDto: CreateTagDto): Promise<Tag> {
+    const { 
+      name, category
+    } = createTagDto;
+    
+
+    const tag = new Tag(
+      name, category
+    );
+
+    await this.save(tag);
+    return tag;
+}
+
+async getTagByName(tagName: string): Promise<ReturnTagDto> {
+  const tag: Tag = await this.findOne({
+    name: tagName
+  })
+  if (tag === undefined) {
+    throw new BadRequestException;
+  }
+  const returnTagDto: ReturnTagDto = new ReturnTagDto(tag);
+  return returnTagDto;
+}
+
+async deleteTag(tagName: string): Promise<ReturnTagDto> {
+  const tag: ReturnTagDto = await this.getTagByName(tagName);
+  await this.delete(
+      { name: tagName }
+  )
+  return tag;
+}
+}

--- a/src/tag/tag.service.spec.ts
+++ b/src/tag/tag.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagService } from './tag.service';
+
+describe('TagService', () => {
+  let service: TagService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TagService],
+    }).compile();
+
+    service = module.get<TagService>(TagService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { ReturnTagDtoCollection } from './dto/return-tag-collection.dto';
+import { ReturnTagDto } from './dto/return-tag.dto';
+import { Tag } from './tag.entity';
+import { TagRepository } from './tag.repository';
+
+@Injectable()
+export class TagService {
+  constructor(
+    @InjectRepository(TagRepository)
+    private tagRepository: TagRepository,
+  ) {}
+    
+    async createTag(createTagDto: CreateTagDto): Promise<ReturnTagDto> {
+      const tag: Tag = await this.tagRepository.createTag(createTagDto);
+      const returnTagDto: ReturnTagDto = new ReturnTagDto(tag)
+      return returnTagDto;
+    };
+
+    async getAllTags(): Promise<ReturnTagDtoCollection> {
+      const tagList: Tag[] = await this.tagRepository.find();
+      const returnTagDtoCollection: ReturnTagDtoCollection = new ReturnTagDtoCollection(tagList);
+      return returnTagDtoCollection;
+    }
+
+    async deleteTag(tagName: string): Promise<ReturnTagDto> {
+      const returnNewsDto: ReturnTagDto = await this.tagRepository.deleteTag(tagName);
+      return returnNewsDto;
+    }
+}


### PR DESCRIPTION
close #39 

### 구현 사항
- Tag create, find all, delete
- News entity 수정(tagsForView -> 화면 표시용 태그 리스트 / tagsForRecommend -> 내부 추천 로직용 태그 리스트)
--> 모두 News와 ManyToMany 관계 (eager: true)
- Tag list 받아서 News에 추가하는 로직 구현