### PR TITLE
추천 뉴스 탐색 기능을 구현한다.

### DIFF
--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -25,7 +25,7 @@ export const message = {
   UPDATE_NEWS_SUCCESS: '뉴스 수정 성공',
   DELETE_NEWS_SUCCESS: '뉴스 삭제 성공',
   SEARCH_NEWS_SUCCESS: '영상 검색 결과 조회 성공',
-  RECOMMEND_NEWS_SUCCESS: '추천 영상 조회 성공',
+  RECOMMENDED_NEWS_SUCCESS: '추천 영상 조회 성공',
   DETAIL_NEWS_SUCCESS: '영상 조회 성공',
   ADD_TAG_TO_NEWS_SUCCESS: '뉴스 태그 추가 성공',
 

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -121,7 +121,6 @@ export class NewsController {
     }
   }
 
-
   @Get('search')
 	async searchNews(
     @Req() req,

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -151,6 +151,23 @@ export class NewsController {
         .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
     }
   }
-  
+
+  @Get('recommend')
+  async getRecommendedNews(
+    @Res() res
+  ): Promise<Response> {
+    try {
+      const data : ExploreNewsDtoCollection = await this.newsService.getRecommendedNews() 
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.RECOMMENDED_NEWS_SUCCESS, data))
+    
+      } catch (error) {
+      logger.error(error)
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
 }
 

--- a/src/news/news.repository.ts
+++ b/src/news/news.repository.ts
@@ -33,7 +33,7 @@ export class NewsRepository extends Repository<News> {
     }
 
     async getNewsById(id: number): Promise<News> {
-        const news: News = await this.findOne({
+        const news: News = await this.findOneOrFail({
             id: id
         })
         return news;

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -192,8 +192,8 @@ export class NewsService {
     const recommendedTag: Tag = await this.tagRepository.getRecommendedTag();
     let recommendedNewsList: News[] = await recommendedTag.forView;
     // 정렬 후 8개 슬라이싱
-    recommendedNewsList = sortByDateAndTitle(recommendedNewsList);
-    recommendedNewsList = recommendedNewsList.slice(8);
+    recommendedNewsList = await sortByDateAndTitle(recommendedNewsList);
+    recommendedNewsList = recommendedNewsList.slice(0, 8);
     // 타입 변경 후 반환
     const exploreNewsDtoList: ExploreNewsDto[] = changeToExploreNewsList(recommendedNewsList);
     const exploreNewsDtoCollection: ExploreNewsDtoCollection = new ExploreNewsDtoCollection(exploreNewsDtoList)

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -83,7 +83,7 @@ export class NewsService {
     const tagsForRecommend: Tag[] = await this.tagRepository.getTagsByNameList(tagListForRecommend);
     const news: News = await this.newsRepository.getNewsById(newsId);
     // 해당 뉴스의 태그(화면 표시용) 초기화
-    await this.newsRepository.resetTagsOfNews(news);
+    const newsResetTag: News = await this.newsRepository.resetTagsOfNews(news);
     // 태그 추가
     await this.newsRepository.addTagsForViewToNews(news, tagsForView);
     await this.newsRepository.addTagsForRecommendToNews(news, tagsForRecommend);
@@ -185,6 +185,19 @@ export class NewsService {
 
     const exploreNewsDtoCollection: ExploreNewsDtoCollection = new ExploreNewsDtoCollection(exploreNewsDtoList)
     return [exploreNewsDtoCollection, paginationInfo];
+  }
+
+  async getRecommendedNews(): Promise<ExploreNewsDtoCollection> {
+    // 추천 태그에 포함된 뉴스 리스트 가져오기
+    const recommendedTag: Tag = await this.tagRepository.getRecommendedTag();
+    let recommendedNewsList: News[] = await recommendedTag.forView;
+    // 정렬 후 8개 슬라이싱
+    recommendedNewsList = sortByDateAndTitle(recommendedNewsList);
+    recommendedNewsList = recommendedNewsList.slice(8);
+    // 타입 변경 후 반환
+    const exploreNewsDtoList: ExploreNewsDto[] = changeToExploreNewsList(recommendedNewsList);
+    const exploreNewsDtoCollection: ExploreNewsDtoCollection = new ExploreNewsDtoCollection(exploreNewsDtoList)
+    return exploreNewsDtoCollection;
   }
 
 }

--- a/src/tag/tag.entity.ts
+++ b/src/tag/tag.entity.ts
@@ -1,5 +1,5 @@
 import { News } from "src/news/news.entity";
-import { BaseEntity, Column, Entity, ManyToMany, PrimaryGeneratedColumn } from "typeorm";
+import { BaseEntity, Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from "typeorm";
 import { Category } from "../news/common/category.enum";
 
 @Entity()
@@ -28,9 +28,11 @@ export class Tag extends BaseEntity {
   category: Category;
 
   @ManyToMany(() => News, (news) => news.tagsForView)
-  forView: News[];
+  @JoinTable()
+  forView: Promise<News[]>;
 
   @ManyToMany(() => News, (news) => news.tagsForRecommend)
-  forRecommend: News[];
+  @JoinTable()
+  forRecommend: Promise<News[]>;
 
 }

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -20,28 +20,34 @@ export class TagRepository extends Repository<Tag> {
     return tag;
 }
 
-async getTagByName(tagName: string): Promise<Tag> {
-  const tag: Tag = await this.findOne({
-    name: tagName
-  })
-  if (tag === undefined) {
-    throw new BadRequestException;
-  }
-  return tag;
-}
-
-async getTagsByNameList(tagList: string[]): Promise<Tag[]> {
-  return await this.createQueryBuilder('tag')
-    .where('tag.name IN (:...tagList)', { tagList })
-    .getMany();
-};
-
-async deleteTag(tagName: string): Promise<ReturnTagDto> {
-    const tag: Tag = await this.getTagByName(tagName);
-    const returnTagDto: ReturnTagDto = new ReturnTagDto(tag);
-    await this.delete(
-      { name: tagName }
-    )
-    return returnTagDto;
+  async getTagByName(tagName: string): Promise<Tag> {
+    const tag: Tag = await this.findOne({
+      name: tagName
+    })
+    if (tag === undefined) {
+      throw new BadRequestException;
     }
+    return tag;
+  }
+
+  async getTagsByNameList(tagList: string[]): Promise<Tag[]> {
+    return await this.createQueryBuilder('tag')
+      .where('tag.name IN (:...tagList)', { tagList })
+      .getMany();
+  };
+
+  async deleteTag(tagName: string): Promise<ReturnTagDto> {
+      const tag: Tag = await this.getTagByName(tagName);
+      const returnTagDto: ReturnTagDto = new ReturnTagDto(tag);
+      await this.delete(
+        { name: tagName }
+      )
+      return returnTagDto;
+  }
+
+  async getRecommendedTag(): Promise<Tag> {
+    return this.findOne({
+      name: "딜리버블 추천"
+    });
+  }
 }


### PR DESCRIPTION
close #41 

### 구현 사항
- 뉴스의 태그 중 딜리버블 추천 태그가 있는 뉴스 중 8개의 정보를 반환한다.
- 정렬 로직은 뉴스 검색과 동일하다.