### PR TITLE
Script를 삭제하는 API를 구현한다.

### DIFF
--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -42,6 +42,7 @@ export const message = {
   DELETE_SCRIPT_SUCCESS: '스크립트 삭제 성공',
   UPDATE_SCRIPT_NAME_SUCCESS: '스크립트 이름 수정 성공',
   // 스크립트 에러
+  NOT_EXISTING_SCRIPT: '없는 스크립트의 id로 요청했습니다.',
   FULL_SCRIPTS_COUNT: '스크립트의 개수가 너무 많아, 더이상 생성할 수 없습니다.',
 
   // 문장

--- a/src/script/repository/script.repository.ts
+++ b/src/script/repository/script.repository.ts
@@ -46,4 +46,5 @@ export class ScriptRepository extends Repository<Script> {
       .getMany();
     return scripts;
   }
+
 }

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -44,7 +44,7 @@ export class ScriptService {
       return await this.scriptRepository.find();
     }
 
-    async deleteScript(scriptId: number): Promise<Script> {
+    async deleteScriptTest(scriptId: number): Promise<Script> {
       const scriptDeleted: Script = await this.scriptRepository.deleteScript(scriptId);
       return scriptDeleted;
     }
@@ -60,6 +60,7 @@ export class ScriptService {
     }
  
     /* 
+    * 스크립트 조회
     * 로그인 한 유저가 이미 해당 News에 스크립트를 가지고 있다면 --> 가져와서 반환
     * 해당 News에 스크립트가 없다면 --> Script Default를 가져와 복사 --> 저장 후 반환
     */
@@ -127,4 +128,25 @@ export class ScriptService {
       await this.createScript(userId, newsId);
     };
 
+    // 스크립트 삭제
+    async deleteScript(userId: number, scriptId: number): Promise<void> {
+      // user가 script의 주인인지 확인
+      const script: Script = await this.checkScriptOwner(userId, scriptId);
+      const scriptDeleted: Script = await this.scriptRepository.deleteScript(scriptId);
+    }
+
+    // 스크립트 조회 - scriptId만 받은 경우
+    async getScriptsByScriptId(userId: number, scriptId: number): Promise<ReturnScriptDtoCollection> {
+      const script: Script = await this.scriptRepository.findOneOrFail(scriptId);
+      const newsId: number = script.news.id;
+      return await this.getScripts(userId, newsId);
+    }
+
+    // 스크립트 삭제 후 조회
+    async deleteAndGetScripts(userId: number, scriptId: number): Promise<ReturnScriptDtoCollection> {
+      const script: Script = await this.scriptRepository.findOneOrFail(scriptId);
+      const newsId: number = script.news.id;
+      await this.scriptRepository.deleteScript(scriptId);
+      return await this.getScripts(userId, newsId);
+    }
 }


### PR DESCRIPTION
close #57 

## 구현 내용
- `Script` 삭제하는 API 구현
- 해당 `Script`의 `owner`가 로그인한 유저인지 확인하는 로직 구현
- 삭제 후 해당 `뉴스` 및 `뉴스에 대한 전체 스크립트` 정보 반환