### PR TITLE
Memo entity를 생성하고, Create, Delete memo API를 구현한다.

### DIFF
--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -53,6 +53,10 @@ export const message = {
   // 문장 에러
   NOT_EXISTING_ORDER: '없는 문장 번호로 요청했습니다.',
 
+  //메모
+  CREATE_MEMO_SUCCESS: '메모 생성 성공',
+  DELETE_MEMO_SUCCESS: '메모 삭제 성공',
+
   // 더미
   CREATE_SCRIPT_DEFAULT_SUCCESS: '기본 스크립트 생성 성공',
   READ_SCRIPT_DEFAULT_SUCCESS: '기본 스크립트 조회 성공',

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -213,7 +213,7 @@ export class NewsController {
   ): Promise<Response> {
     try {
       const data: ReturnNewsDto = await this.newsService.getNews(newsId);
-      const data2: ReturnScriptDefaultDto = await this.dummyService.getScriptDefault(newsId);
+      const data2: ReturnScriptDefaultDto[] = [await this.dummyService.getScriptDefault(newsId)];
       return res
         .status(statusCode.OK)
         .send(util.success(statusCode.OK, message.READ_NEWS_DETAIL_SUCCESS, data, data2))

--- a/src/news/news.module.ts
+++ b/src/news/news.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from 'src/auth/auth.module';
 import { DummyService } from 'src/dummy/dummy.service';
 import { ScriptDefaultRepository } from 'src/dummy/repository/script-default.repository';
 import { SentenceDefaultRepository } from 'src/dummy/repository/sentence-default.repository';
+import { MemoRepository } from 'src/script/repository/memo.repository';
 import { ScriptRepository } from 'src/script/repository/script.repository';
 import { SentenceRepository } from 'src/script/repository/sentence.repository';
 import { ScriptService } from 'src/script/script.service';
@@ -16,7 +17,7 @@ import { NewsService } from './news.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      NewsRepository, TagRepository, ScriptRepository, SentenceRepository, UserRepository, ScriptDefaultRepository, SentenceDefaultRepository
+      NewsRepository, TagRepository, ScriptRepository, SentenceRepository, UserRepository, ScriptDefaultRepository, SentenceDefaultRepository, MemoRepository
     ]),
     AuthModule,
   ],

--- a/src/script/dto/create-memo.dto.ts
+++ b/src/script/dto/create-memo.dto.ts
@@ -1,0 +1,7 @@
+import { Script } from "../entity/script.entity";
+
+export class CreateMemoDto { 
+  script: Script;
+  order: number;
+  content: string;
+}

--- a/src/script/entity/memo.entity.ts
+++ b/src/script/entity/memo.entity.ts
@@ -1,0 +1,20 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Script } from "./script.entity";
+
+@Entity()
+export class Memo extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Script, (script) => script.memos, {
+    onDelete: 'CASCADE',
+  })
+  script: Script;
+
+  @Column()
+  order: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  content: string;
+}

--- a/src/script/entity/script.entity.ts
+++ b/src/script/entity/script.entity.ts
@@ -1,6 +1,7 @@
 import { News } from "src/news/news.entity";
 import { User } from "src/user/user.entity";
 import { BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Memo } from "./memo.entity";
 import { Sentence } from "./sentence.entity";
 
 @Entity()
@@ -26,5 +27,10 @@ export class Script extends BaseEntity {
     eager: true,
   })
   sentences: Sentence[];
+
+  @OneToMany(() => Memo, (memo) => memo.script, {
+    eager: true,
+  })
+  memos: Memo[];
 
 }

--- a/src/script/repository/memo.repository.ts
+++ b/src/script/repository/memo.repository.ts
@@ -1,0 +1,28 @@
+import { EntityRepository, Repository } from "typeorm";
+import { CreateMemoDto } from "../dto/create-memo.dto";
+import { Memo } from "../entity/memo.entity";
+
+@EntityRepository(Memo)
+export class MemoRepository extends Repository<Memo> {
+  async createMemo(createMemoDto: CreateMemoDto): Promise<Memo> {
+    const memo: Memo = new Memo()
+
+    memo.script = createMemoDto.script;
+    memo.order = createMemoDto.order;
+    memo.content = createMemoDto.content;
+    
+    await memo.save();
+    return memo;
+  }
+
+  async deleteMemo(memoId): Promise<Memo> {
+    console.log(memoId);
+    const memoDeleted: Memo = await this.findOneOrFail(memoId);
+    await this.createQueryBuilder()
+      .delete()
+      .from(Memo)
+      .where("id = :memoId", { memoId })
+      .execute()
+    return memoDeleted;
+  }
+}

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -6,8 +6,10 @@ import { util } from 'src/modules/response/response.util';
 import { ReturnNewsDto } from 'src/news/dto/return-news.dto';
 import { NewsService } from 'src/news/news.service';
 import { User } from 'src/user/user.entity';
+import { CreateMemoDto } from './dto/create-memo.dto';
 import { ReturnScriptDto } from './dto/return-script.dto';
 import { ReturnScriptDtoCollection } from './dto/return-script.dto.collection';
+import { Memo } from './entity/memo.entity';
 import { Script } from './entity/script.entity';
 import { Sentence } from './entity/sentence.entity';
 import { ScriptService } from './script.service';
@@ -190,6 +192,48 @@ export class ScriptController {
       if (error.name === "EntityNotFound") {
         return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NOT_EXISTING_SCRIPT))
       }
+      return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+
+  @Post('memo/create/:scriptId')
+  @UseGuards(JwtAuthGuard)
+  async createMemo(
+    @Req() req,
+    @Res() res,
+    @Param('scriptId') scriptId: number
+  ): Promise<Response> {
+    try {
+      const createMemoDto: CreateMemoDto = new CreateMemoDto();
+      const script: Script = await this.scriptService.getScriptById(scriptId);
+      createMemoDto.script = script;
+      createMemoDto.order = req.body.order;
+      createMemoDto.content = req.body.content;
+
+      const data: Memo = await this.scriptService.createMemo(createMemoDto);
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.CREATE_MEMO_SUCCESS, data))
+    } catch (error) {
+      logger.error(error);
+      return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
+    }
+  }
+
+  @Delete('memo/delete/:memoId')
+  @UseGuards(JwtAuthGuard)
+  async deleteMemo(
+    @Req() req,
+    @Res() res,
+    @Param('memoId') memoId: number
+  ): Promise<Response> {
+    try {
+      const data: Memo = await this.scriptService.deleteMemo(memoId);
+      return res
+        .status(statusCode.OK)
+        .send(util.success(statusCode.OK, message.DELETE_MEMO_SUCCESS, data))
+    } catch (error) {
+      logger.error(error);
       return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR))
     }
   }

--- a/src/script/script.module.ts
+++ b/src/script/script.module.ts
@@ -11,11 +11,12 @@ import { ScriptDefaultRepository } from 'src/dummy/repository/script-default.rep
 import { NewsService } from 'src/news/news.service';
 import { TagRepository } from 'src/tag/tag.repository';
 import { AuthService } from 'src/auth/auth.service';
+import { MemoRepository } from './repository/memo.repository';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      ScriptRepository, UserRepository, NewsRepository, SentenceRepository, ScriptDefaultRepository, TagRepository,
+      ScriptRepository, SentenceRepository, MemoRepository, UserRepository, NewsRepository, ScriptDefaultRepository, TagRepository,
     ]),
   ],
   controllers: [ScriptController],

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -8,11 +8,14 @@ import { NewsRepository } from 'src/news/news.repository';
 import { User } from 'src/user/user.entity';
 import { UserRepository } from 'src/user/user.repository';
 import { SCRIPT_DEFAULT_NAME } from './common/script-default-name';
+import { CreateMemoDto } from './dto/create-memo.dto';
 import { CreateSentenceDto } from './dto/create-sentence.dto';
 import { ReturnScriptDto } from './dto/return-script.dto';
 import { ReturnScriptDtoCollection } from './dto/return-script.dto.collection';
+import { Memo } from './entity/memo.entity';
 import { Script } from './entity/script.entity';
 import { Sentence } from './entity/sentence.entity';
+import { MemoRepository } from './repository/memo.repository';
 import { ScriptRepository } from './repository/script.repository';
 import { SentenceRepository } from './repository/sentence.repository';
 import { changeScriptsToReturn } from './utils/change-scripts-to-return';
@@ -25,12 +28,14 @@ export class ScriptService {
   constructor(
     @InjectRepository(ScriptRepository)
     private scriptRepository: ScriptRepository,
+    @InjectRepository(SentenceRepository)
+    private sentenceRepository: SentenceRepository,
+    @InjectRepository(MemoRepository)
+    private memoRepository: MemoRepository,
     @InjectRepository(UserRepository)
     private userRepository: UserRepository,
     @InjectRepository(NewsRepository)
     private newsRepository: NewsRepository,
-    @InjectRepository(SentenceRepository)
-    private sentenceRepository: SentenceRepository,
     @InjectRepository(ScriptDefaultRepository)
     private scriptDefaultRepository: ScriptDefaultRepository,
   ) {}
@@ -43,6 +48,10 @@ export class ScriptService {
 
     async getAllScript(): Promise<Script[]> {
       return await this.scriptRepository.find();
+    }
+
+    async getScriptById(scriptId: number): Promise<Script> {
+      return await this.scriptRepository.findOneOrFail(scriptId);
     }
 
     async deleteScriptTest(scriptId: number): Promise<Script> {
@@ -182,6 +191,18 @@ export class ScriptService {
       }
       const returnScriptDto: ReturnScriptDto = new ReturnScriptDto(script);
       return returnScriptDto;
+    }
+
+    // 메모 생성
+    async createMemo(createMemoDto: CreateMemoDto): Promise<Memo> {
+      const memo: Memo = await this.memoRepository.createMemo(createMemoDto);
+      return memo;
+    }
+
+    // 메모 삭제
+    async deleteMemo(memoId: number): Promise<Memo> {
+      const memoDeleted: Memo = await this.memoRepository.deleteMemo(memoId);
+      return memoDeleted;
     }
 
 }


### PR DESCRIPTION
close #62 

## 구현 내용
- `Memo` entity 생성
- `Memo` create, delete API 구현

## 추후 구현할 내용
- `Memo` create, delete 시 해당 `Memo`를 포함하는 `Script` 정보를 반환
- 모든 `Script` 정보 반환 시, `memos`를 포함