### PR TITLE
Script 이름 생성 로직을 추가한다.

### DIFF
--- a/src/news/news.module.ts
+++ b/src/news/news.module.ts
@@ -5,6 +5,7 @@ import { DummyService } from 'src/dummy/dummy.service';
 import { ScriptDefaultRepository } from 'src/dummy/repository/script-default.repository';
 import { SentenceDefaultRepository } from 'src/dummy/repository/sentence-default.repository';
 import { MemoRepository } from 'src/script/repository/memo.repository';
+import { ScriptCountRepository } from 'src/script/repository/script-count.repository';
 import { ScriptRepository } from 'src/script/repository/script.repository';
 import { SentenceRepository } from 'src/script/repository/sentence.repository';
 import { ScriptService } from 'src/script/script.service';
@@ -17,7 +18,7 @@ import { NewsService } from './news.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      NewsRepository, TagRepository, ScriptRepository, SentenceRepository, UserRepository, ScriptDefaultRepository, SentenceDefaultRepository, MemoRepository
+      NewsRepository, TagRepository, ScriptRepository, SentenceRepository, UserRepository, ScriptDefaultRepository, SentenceDefaultRepository, MemoRepository, ScriptCountRepository, 
     ]),
     AuthModule,
   ],

--- a/src/script/common/script-default-name.ts
+++ b/src/script/common/script-default-name.ts
@@ -1,1 +1,1 @@
-export const SCRIPT_DEFAULT_NAME: string = "스크립트 1";
+export const SCRIPT_DEFAULT_NAME: string = "스크립트 ";

--- a/src/script/entity/script-count.entity.ts
+++ b/src/script/entity/script-count.entity.ts
@@ -1,23 +1,21 @@
+import { User } from "src/user/user.entity";
 import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Script } from "./script.entity";
 
 @Entity()
-export class Memo extends BaseEntity {
+export class ScriptCount extends BaseEntity {
 
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Script, (script) => script.memos, {
+  @ManyToOne(() => User, (user) => user.scriptCounts, {
     onDelete: 'CASCADE',
   })
-  script: Script;
+  user: User;
 
   @Column()
-  order: number;
+  newsId: number;
 
   @Column()
-  startIndex: number;
+  count: number;
 
-  @Column({ type: 'varchar', length: 255 })
-  content: string;
 }

--- a/src/script/entity/script-count.entity.ts
+++ b/src/script/entity/script-count.entity.ts
@@ -1,0 +1,23 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Script } from "./script.entity";
+
+@Entity()
+export class Memo extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Script, (script) => script.memos, {
+    onDelete: 'CASCADE',
+  })
+  script: Script;
+
+  @Column()
+  order: number;
+
+  @Column()
+  startIndex: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  content: string;
+}

--- a/src/script/repository/script-count.repository.ts
+++ b/src/script/repository/script-count.repository.ts
@@ -1,16 +1,27 @@
+import { User } from "src/user/user.entity";
 import { EntityRepository, Repository } from "typeorm";
 import { ScriptCount } from "../entity/script-count.entity";
 
 @EntityRepository(ScriptCount)
 export class ScriptCountRepository extends Repository<ScriptCount> {
-  // async createMemo(createMemoDto: CreateMemoDto): Promise<Memo> {
-  //   const memo: Memo = new Memo()
-  //   memo.script = createMemoDto.script;
-  //   memo.order = createMemoDto.order;
-  //   memo.startIndex = createMemoDto.startIndex;
-  //   memo.content = createMemoDto.content;
-    
-  //   await memo.save();
-  //   return memo;
-  // }
+
+  async createScriptCount(user: User, newsId: number): Promise<ScriptCount> {
+    const scriptCount: ScriptCount = new ScriptCount();
+
+    scriptCount.user = user;
+    scriptCount.newsId = newsId;
+    scriptCount.count = 1;
+
+    scriptCount.save();
+    return scriptCount;
+  }
+
+  async getScriptCount(userId: number, newsId: number): Promise<ScriptCount> {
+    return await this.createQueryBuilder('scriptCount')
+      .leftJoinAndSelect('scriptCount.user', 'user')
+      .where('user.id = :userId', { userId: userId })
+      .andWhere('newsId = :newsId', { newsId: newsId})
+      .getOne();
+  }
+
 }

--- a/src/script/repository/script-count.repository.ts
+++ b/src/script/repository/script-count.repository.ts
@@ -1,0 +1,16 @@
+import { EntityRepository, Repository } from "typeorm";
+import { ScriptCount } from "../entity/script-count.entity";
+
+@EntityRepository(ScriptCount)
+export class ScriptCountRepository extends Repository<ScriptCount> {
+  // async createMemo(createMemoDto: CreateMemoDto): Promise<Memo> {
+  //   const memo: Memo = new Memo()
+  //   memo.script = createMemoDto.script;
+  //   memo.order = createMemoDto.order;
+  //   memo.startIndex = createMemoDto.startIndex;
+  //   memo.content = createMemoDto.content;
+    
+  //   await memo.save();
+  //   return memo;
+  // }
+}

--- a/src/script/repository/script.repository.ts
+++ b/src/script/repository/script.repository.ts
@@ -6,11 +6,12 @@ import { Script } from "../entity/script.entity";
 @EntityRepository(Script)
 export class ScriptRepository extends Repository<Script> {
   async createScript(user: User, news: News, scriptName: string): Promise<Script> {
-    const script = new Script()
+    const script: Script = new Script()
 
     script.name = scriptName;
     script.user = user;
     script.news = news;
+    script.memos = [];
 
     await this.save(script);
     return script;
@@ -31,6 +32,7 @@ export class ScriptRepository extends Repository<Script> {
       .leftJoinAndSelect('script.user', 'user')
       .leftJoinAndSelect('script.news', 'news')
       .leftJoinAndSelect('script.sentences', 'sentences')
+      .leftJoinAndSelect('script.memos', 'memos')
       .where('script.id = :scriptId', { scriptId: scriptId })
       .getOneOrFail();
     return script;

--- a/src/script/repository/sentence.repository.ts
+++ b/src/script/repository/sentence.repository.ts
@@ -1,8 +1,5 @@
-import { News } from "src/news/news.entity";
-import { User } from "src/user/user.entity";
 import { EntityRepository, Repository } from "typeorm";
 import { CreateSentenceDto } from "../dto/create-sentence.dto";
-import { Script } from "../entity/script.entity";
 import { Sentence } from "../entity/sentence.entity";
 
 @EntityRepository(Sentence)

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -36,7 +36,7 @@ export class ScriptController {
     const userId: number = req.user.id;
     const newsId: number = req.body.newsId;
     const scriptName: string = req.body.name;
-    const data: Script = await this.scriptService.createScriptTest(userId, newsId, scriptName);
+    const data: Script = await this.scriptService.createScript(userId, newsId, scriptName);
     return res
     .status(statusCode.OK)
     .send(util.success(statusCode.OK, message.CREATE_SCRIPT_SUCCESS, data))

--- a/src/script/script.module.ts
+++ b/src/script/script.module.ts
@@ -12,11 +12,12 @@ import { NewsService } from 'src/news/news.service';
 import { TagRepository } from 'src/tag/tag.repository';
 import { AuthService } from 'src/auth/auth.service';
 import { MemoRepository } from './repository/memo.repository';
+import { ScriptCountRepository } from './repository/script-count.repository';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      ScriptRepository, SentenceRepository, MemoRepository, UserRepository, NewsRepository, ScriptDefaultRepository, TagRepository,
+      ScriptRepository, SentenceRepository, MemoRepository, UserRepository, NewsRepository, ScriptDefaultRepository, TagRepository, ScriptCountRepository,
     ]),
   ],
   controllers: [ScriptController],

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -17,6 +17,7 @@ import { Memo } from './entity/memo.entity';
 import { Script } from './entity/script.entity';
 import { Sentence } from './entity/sentence.entity';
 import { MemoRepository } from './repository/memo.repository';
+import { ScriptCountRepository } from './repository/script-count.repository';
 import { ScriptRepository } from './repository/script.repository';
 import { SentenceRepository } from './repository/sentence.repository';
 import { changeScriptsToReturn } from './utils/change-scripts-to-return';
@@ -39,6 +40,8 @@ export class ScriptService {
     private newsRepository: NewsRepository,
     @InjectRepository(ScriptDefaultRepository)
     private scriptDefaultRepository: ScriptDefaultRepository,
+    @InjectRepository(ScriptCountRepository)
+    private scriptCountRepository: ScriptCountRepository,
   ) {}
     
     async createScriptTest(userId: number, newsId: number, scriptName: string): Promise<Script> {

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -14,6 +14,7 @@ import { DeleteMemoDto } from './dto/delete-memo.dto';
 import { ReturnScriptDto } from './dto/return-script.dto';
 import { ReturnScriptDtoCollection } from './dto/return-script.dto.collection';
 import { Memo } from './entity/memo.entity';
+import { ScriptCount } from './entity/script-count.entity';
 import { Script } from './entity/script.entity';
 import { Sentence } from './entity/sentence.entity';
 import { MemoRepository } from './repository/memo.repository';
@@ -44,7 +45,7 @@ export class ScriptService {
     private scriptCountRepository: ScriptCountRepository,
   ) {}
     
-    async createScriptTest(userId: number, newsId: number, scriptName: string): Promise<Script> {
+    async createScript(userId: number, newsId: number, scriptName: string): Promise<Script> {
       const user: User = await this.userRepository.findOne(userId);
       const news: News = await this.newsRepository.getNewsById(newsId);
       return await this.scriptRepository.createScript(user, news, scriptName);
@@ -90,7 +91,7 @@ export class ScriptService {
       const scriptsCheck: SCRIPTS_COUNT_CHECK = scriptsCountCheck(scripts);
       // script list가 비어있다면 -> 새로 만든 후 (리스트 형식으로) 반환
       if (scriptsCheck === SCRIPTS_COUNT_CHECK.Empty) {
-        const returnScriptDto: ReturnScriptDto = await this.createScript(userId, newsId);
+        const returnScriptDto: ReturnScriptDto = await this.createScriptByDefault(userId, newsId);
         const returnScriptDtoCollection: ReturnScriptDtoCollection = new ReturnScriptDtoCollection([returnScriptDto]);
         return returnScriptDtoCollection;
       }
@@ -100,12 +101,15 @@ export class ScriptService {
       return returnScriptDtoCollection
     }
 
-    // 새로운 스크립트 생성
-    async createScript(userId: number, newsId: number): Promise<ReturnScriptDto> {
+    // 새로운 스크립트 생성 (Script Default 활용)
+    async createScriptByDefault(userId: number, newsId: number): Promise<ReturnScriptDto> {
       // Script Default 가져오기
       const scriptDefault: ScriptDefault = await this.scriptDefaultRepository.getScriptDefaultByNewsId(newsId);
+      // Script 이름 설정을 위한, Script count 조회하기
+      const count: number = await this.getOrCreateScriptCount(userId, newsId);
       // Script 객체 생성 및 저장
-      const script: Script = await this.createScriptTest(userId, newsId, SCRIPT_DEFAULT_NAME);
+      const scriptName: string = SCRIPT_DEFAULT_NAME + count;
+      const script: Script = await this.createScript(userId, newsId, scriptName);
       // Script Default가 가지고 있는 Sentence들을 list에 담고, for문으로 같은 값을 가지는 Sentence들을 생성한다.
       const sentenceDefaults: SentenceDefault[] = scriptDefault.sentenceDefaults;
       for (var i in sentenceDefaults) {
@@ -120,6 +124,19 @@ export class ScriptService {
       const scriptResult: Script = await this.scriptRepository.getScriptById(script.id);
       const returnScriptDto: ReturnScriptDto = new ReturnScriptDto(scriptResult);
       return returnScriptDto;
+    }
+
+    // 스크립트 이름 생성을 위해 Script count 조회 or 생성
+    async getOrCreateScriptCount(userId: number, newsId: number): Promise<number> {
+      const scriptCount: ScriptCount = await this.scriptCountRepository.getScriptCount(userId, newsId);
+      if (!scriptCount) {
+        const user: User = await this.userRepository.findOneOrFail(userId);
+        const scriptCount: ScriptCount = await this.scriptCountRepository.createScriptCount(user, newsId);
+        return scriptCount.count;
+      }
+      scriptCount.count += 1;
+      scriptCount.save();
+      return scriptCount.count;
     }
 
     // 스크립트 이름 변경
@@ -150,7 +167,7 @@ export class ScriptService {
       if (scriptsCheck === SCRIPTS_COUNT_CHECK.Full) {
         throw BadRequestException;
       }
-      await this.createScript(userId, newsId);
+      await this.createScriptByDefault(userId, newsId);
     };
 
     // 스크립트 삭제

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -4,6 +4,7 @@ import { BaseEntity, Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGe
 import { Social } from "../auth/common/Social";
 import { News } from "src/news/news.entity";
 import { Script } from "src/script/entity/script.entity";
+import { ScriptCount } from "src/script/entity/memo.entity copy";
 
 @Entity()
 export class User extends BaseEntity {
@@ -59,4 +60,8 @@ export class User extends BaseEntity {
 
     @OneToMany(() => Script, (script) => script.user)
     scripts: Promise<Script[]>;
+
+    @OneToMany(() => ScriptCount, (scriptCount) => scriptCount.user)
+    scriptCounts: ScriptCount[];
+    
 }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -4,7 +4,7 @@ import { BaseEntity, Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGe
 import { Social } from "../auth/common/Social";
 import { News } from "src/news/news.entity";
 import { Script } from "src/script/entity/script.entity";
-import { ScriptCount } from "src/script/entity/memo.entity copy";
+import { ScriptCount } from "src/script/entity/script-count.entity";
 
 @Entity()
 export class User extends BaseEntity {
@@ -63,5 +63,5 @@ export class User extends BaseEntity {
 
     @OneToMany(() => ScriptCount, (scriptCount) => scriptCount.user)
     scriptCounts: ScriptCount[];
-    
+
 }


### PR DESCRIPTION
close #71 

## 구현 내용
- `Script` count entity, repository 생성
- `Script` 생성 시, `user`와 `news`에 대하여 생성 횟수를 세는 Script count 구현
- `Script` 생성 시, name`을` `기본 이름("스크립트 ")`과 `Script count`의 합으로 생성 (ex: `스크립트 4`)