### PR TITLE
fix: recording Restful API status 명시 반환

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+redeploy:
+	@echo "building..."
+	npm run build
+
+	@echo "restarting pm2..."
+	pm2 restart main

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -46,7 +46,7 @@ export const message = {
   READ_ALL_SCRIPTS_SUCCESS: '모든 스크립트 조회 성공',
   DELETE_SCRIPT_SUCCESS: '스크립트 삭제 성공',
   UPDATE_SCRIPT_NAME_SUCCESS: '스크립트 이름 수정 성공',
-  
+
   // 스크립트 에러
   NOT_EXISTING_SCRIPT: '없는 스크립트의 id로 요청했습니다.',
   FULL_SCRIPTS_COUNT: '스크립트의 개수가 너무 많아, 더이상 생성할 수 없습니다.',
@@ -57,7 +57,10 @@ export const message = {
   NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
   NOT_FOUND_RECORDING: '해당 녹음이 없습니다.',
   NOT_FOUND_RECORDING_ALL: '사용자가 가지고 있는 녹음이 없습니다.',
+
+  // 녹음
   FOUND_RECORDING_ALL: '사용자 전체 녹음 조회 성공',
+  FOUND_RECORDING: '녹음 조회 성공',
   CREATE_RECORDING_SUCCESS: '녹음 생성 성공',
   DELETE_RECORDING_SUCCESS: '녹음 삭제 성공',
   CHANGE_NAME_OF_RECORDING_SUCCESS: '녹음 이름 변경 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -56,6 +56,8 @@ export const message = {
   NOT_FOUND_RECORDING: '해당 녹음이 없습니다.',
   CREATE_RECORDING_SUCCESS: '녹음 생성 성공',
   DELETE_RECORDING_SUCCESS: '녹음 삭제 성공',
+  CHANGE_NAME_OF_RECORDING_SUCCESS: '녹음 이름 변경 성공',
+  CHANGE_NAME_OF_RECORDING_FAIL: '녹음 이름 변경 실패',
 
   // 문장
   CREATE_SENTENCE_SUCCESS: '문장 생성 성공',
@@ -87,4 +89,5 @@ export const message = {
 
   CREATE_MEMO_GUIDE_SUCCESS: '스피치 가이드 메모 생성 성공',
   DELETE_MEMO_GUIDE_SUCCESS: '스피치 가이드 메모 삭제 성공',
+
 };

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -52,10 +52,12 @@ export const message = {
   FULL_SCRIPTS_COUNT: '스크립트의 개수가 너무 많아, 더이상 생성할 수 없습니다.',
   NOT_OWNER_OF_SCRIPT: '로그인한 유저가 해당 스크립트를 가지고 있지 않습니다.',
   NOT_REMOVABLE_SCRIPT: '스크립트가 1개이므로 삭제할 수 없습니다.',
-  
+
   // 녹음 에러
   NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
   NOT_FOUND_RECORDING: '해당 녹음이 없습니다.',
+  NOT_FOUND_RECORDING_ALL: '사용자가 가지고 있는 녹음이 없습니다.',
+  FOUND_RECORDING_ALL: '사용자 전체 녹음 조회 성공',
   CREATE_RECORDING_SUCCESS: '녹음 생성 성공',
   DELETE_RECORDING_SUCCESS: '녹음 삭제 성공',
   CHANGE_NAME_OF_RECORDING_SUCCESS: '녹음 이름 변경 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -53,6 +53,7 @@ export const message = {
   NOT_REMOVABLE_SCRIPT: '스크립트가 1개이므로 삭제할 수 없습니다.',
   // 녹음 에러
   NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
+  CREATE_RECORDING_SUCCESS: '녹음 생성 성공',
 
   // 문장
   CREATE_SENTENCE_SUCCESS: '문장 생성 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -57,6 +57,8 @@ export const message = {
   NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
   NOT_FOUND_RECORDING: '해당 녹음이 없습니다.',
   NOT_FOUND_RECORDING_ALL: '사용자가 가지고 있는 녹음이 없습니다.',
+  NOT_FOUND_SCRIPT_OR_RECORDING:
+    '사용자에 해당 스크립트가 없거나 스크립트에 녹음이 없습니다.',
 
   // 녹음
   FOUND_RECORDING_ALL: '사용자 전체 녹음 조회 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -53,7 +53,9 @@ export const message = {
   NOT_REMOVABLE_SCRIPT: '스크립트가 1개이므로 삭제할 수 없습니다.',
   // 녹음 에러
   NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
+  NOT_FOUND_RECORDING: '해당 녹음이 없습니다.',
   CREATE_RECORDING_SUCCESS: '녹음 생성 성공',
+  DELETE_RECORDING_SUCCESS: '녹음 삭제 성공',
 
   // 문장
   CREATE_SENTENCE_SUCCESS: '문장 생성 성공',

--- a/src/modules/response/response.message.ts
+++ b/src/modules/response/response.message.ts
@@ -51,6 +51,8 @@ export const message = {
   FULL_SCRIPTS_COUNT: '스크립트의 개수가 너무 많아, 더이상 생성할 수 없습니다.',
   NOT_OWNER_OF_SCRIPT: '로그인한 유저가 해당 스크립트를 가지고 있지 않습니다.',
   NOT_REMOVABLE_SCRIPT: '스크립트가 1개이므로 삭제할 수 없습니다.',
+  // 녹음 에러
+  NOT_FOUND_SCRIPT: '해당 스크립트가 없습니다.',
 
   // 문장
   CREATE_SENTENCE_SUCCESS: '문장 생성 성공',

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -576,7 +576,13 @@ export class ScriptController {
     if (response.deleted) {
       return res
         .status(statusCode.OK)
-        .send(statusCode.OK, message.DELETE_RECORDING_SUCCESS, response);
+        .send(
+          util.success(
+            statusCode.OK,
+            message.DELETE_RECORDING_SUCCESS,
+            response,
+          ),
+        );
     } else {
       return res
         .status(statusCode.NOT_FOUND)

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -606,7 +606,11 @@ export class ScriptController {
     );
 
     console.log('response ::: ', response);
-    if (!response || response.message === message.NOT_FOUND_RECORDING) {
+    if (
+      !response ||
+      response.message === message.NOT_FOUND_RECORDING ||
+      response.message === message.NOT_FOUND_SCRIPT
+    ) {
       return res
         .status(statusCode.NOT_FOUND)
         .send(

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -552,7 +552,7 @@ export class ScriptController {
         .status(statusCode.NOT_FOUND)
         .send(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT);
     }
-    return res.status(statusCode.CREATED).send(statusCode.CREATED, response);
+    return res.status(statusCode.OK).send(statusCode.OK, response);
   }
 
   @Post('/recording/delete')

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -561,13 +561,27 @@ export class ScriptController {
 
   @Post('/recording/delete')
   @UseGuards(JwtAuthGuard)
-  deleteRecording(@Body() body, @Req() req) {
+  async deleteRecording(@Body() body, @Req() req, @Res() res) {
     const userInfo: ReturnUserDto = req.user;
     const userId = userInfo.id;
     const scriptId = body.scriptId;
     const link = body.link;
 
-    return this.scriptService.deleteRecording(userId, scriptId, link);
+    const response = await this.scriptService.deleteRecording(
+      userId,
+      scriptId,
+      link,
+    );
+
+    if (response.deleted) {
+      return res
+        .status(statusCode.OK)
+        .send(statusCode.OK, message.DELETE_RECORDING_SUCCESS, response);
+    } else {
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING));
+    }
   }
 
   @Post('/recording/change-name')

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -633,11 +633,20 @@ export class ScriptController {
 
   @Get('/recording/find/all')
   @UseGuards(JwtAuthGuard)
-  getUserAllRecording(@Body() body, @Req() req) {
+  async getUserAllRecording(@Body() body, @Req() req, @Res() res) {
     const userInfo: ReturnUserDto = req.user;
     const userId = userInfo.id;
 
-    return this.scriptService.getUserAllRecording(userId);
+    const response = await this.scriptService.getUserAllRecording(userId);
+
+    if (!response) {
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING_ALL));
+    }
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.FOUND_RECORDING_ALL, response));
   }
 
   @Get('/recording/find')
@@ -645,8 +654,6 @@ export class ScriptController {
   getRecordingByScriptId(@Body() body, @Req() req, @Query() query) {
     const userInfo: ReturnUserDto = req.user;
     const userId = userInfo.id;
-    // const scriptId = req.params.scriptId;
-    // get from query param
     const scriptId = query.scriptId;
     console.log('getRecordingByScriptId scriptId :: ', scriptId);
 

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -606,7 +606,7 @@ export class ScriptController {
     );
 
     console.log('response ::: ', response);
-    if (!response || response.message === message.NOT_FOUND_SCRIPT) {
+    if (!response || response.message === message.NOT_FOUND_RECORDING) {
       return res
         .status(statusCode.NOT_FOUND)
         .send(

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -521,10 +521,11 @@ export class ScriptController {
   @Post('/recording/upload')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('file'))
-  uploadRecording(
+  async uploadRecording(
     @Body() body,
     @UploadedFile() file: Express.Multer.File,
     @Req() req,
+    @Res() res,
   ) {
     const scriptId = body.scriptId;
     const name = body.name;
@@ -537,7 +538,7 @@ export class ScriptController {
 
     console.log('FILE ::: ', file);
 
-    return this.scriptService.uploadRecordingToS3(
+    const response = await this.scriptService.uploadRecordingToS3(
       userId,
       parseInt(scriptId),
       name,
@@ -545,6 +546,13 @@ export class ScriptController {
       date,
       file.buffer,
     );
+
+    if (response.status === statusCode.NOT_FOUND) {
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.success(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT));
+    }
+    return res.status(statusCode.CREATED).send(response);
   }
 
   @Post('/recording/delete')

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -667,10 +667,18 @@ export class ScriptController {
       scriptId,
     );
 
-    if (!response || response.message === message.NOT_FOUND_RECORDING) {
+    if (
+      !response ||
+      response.message === message.NOT_FOUND_SCRIPT_OR_RECORDING
+    ) {
       return res
         .status(statusCode.NOT_FOUND)
-        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING));
+        .send(
+          util.fail(
+            statusCode.NOT_FOUND,
+            message.NOT_FOUND_SCRIPT_OR_RECORDING,
+          ),
+        );
     }
     return res
       .status(statusCode.OK)

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -605,7 +605,8 @@ export class ScriptController {
       newName,
     );
 
-    if (!response || response.status === statusCode.NOT_FOUND) {
+    console.log('response ::: ', response);
+    if (!response || response.message === message.NOT_FOUND_SCRIPT) {
       return res
         .status(statusCode.NOT_FOUND)
         .send(

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -583,11 +583,10 @@ export class ScriptController {
             response,
           ),
         );
-    } else {
-      return res
-        .status(statusCode.NOT_FOUND)
-        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING));
     }
+    return res
+      .status(statusCode.NOT_FOUND)
+      .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING));
   }
 
   @Post('/recording/change-name')
@@ -606,7 +605,7 @@ export class ScriptController {
       newName,
     );
 
-    if (!response) {
+    if (!response || response.status === statusCode.NOT_FOUND) {
       return res
         .status(statusCode.NOT_FOUND)
         .send(

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -550,9 +550,13 @@ export class ScriptController {
     if (response.status === statusCode.NOT_FOUND) {
       return res
         .status(statusCode.NOT_FOUND)
-        .send(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT);
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT));
     }
-    return res.status(statusCode.OK).send(statusCode.OK, response);
+    return res
+      .status(statusCode.OK)
+      .send(
+        util.success(statusCode.OK, message.CREATE_RECORDING_SUCCESS, response),
+      );
   }
 
   @Post('/recording/delete')

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -651,12 +651,29 @@ export class ScriptController {
 
   @Get('/recording/find')
   @UseGuards(JwtAuthGuard)
-  getRecordingByScriptId(@Body() body, @Req() req, @Query() query) {
+  async getRecordingByScriptId(
+    @Body() body,
+    @Req() req,
+    @Res() res,
+    @Query() query,
+  ) {
     const userInfo: ReturnUserDto = req.user;
     const userId = userInfo.id;
     const scriptId = query.scriptId;
     console.log('getRecordingByScriptId scriptId :: ', scriptId);
 
-    return this.scriptService.getRecordingByScriptId(userId, scriptId);
+    const response = await this.scriptService.getRecordingByScriptId(
+      userId,
+      scriptId,
+    );
+
+    if (!response || response.message === message.NOT_FOUND_RECORDING) {
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_RECORDING));
+    }
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.FOUND_RECORDING, response));
   }
 }

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -592,19 +592,39 @@ export class ScriptController {
 
   @Post('/recording/change-name')
   @UseGuards(JwtAuthGuard)
-  changeNameOfRecording(@Body() body, @Req() req) {
+  async changeNameOfRecording(@Body() body, @Req() req, @Res() res) {
     const userInfo: ReturnUserDto = req.user;
     const userId = userInfo.id;
     const scriptId = body.scriptId;
     const link = body.link;
     const newName = body.newName;
 
-    return this.scriptService.changeNameOfRecording(
+    const response = await this.scriptService.changeNameOfRecording(
       userId,
       scriptId,
       link,
       newName,
     );
+
+    if (!response) {
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(
+          util.fail(
+            statusCode.NOT_FOUND,
+            message.CHANGE_NAME_OF_RECORDING_FAIL,
+          ),
+        );
+    }
+    return res
+      .status(statusCode.OK)
+      .send(
+        util.success(
+          statusCode.OK,
+          message.CHANGE_NAME_OF_RECORDING_SUCCESS,
+          response,
+        ),
+      );
   }
 
   @Get('/recording/find/all')

--- a/src/script/script.controller.ts
+++ b/src/script/script.controller.ts
@@ -550,9 +550,9 @@ export class ScriptController {
     if (response.status === statusCode.NOT_FOUND) {
       return res
         .status(statusCode.NOT_FOUND)
-        .send(util.success(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT));
+        .send(statusCode.NOT_FOUND, message.NOT_FOUND_SCRIPT);
     }
-    return res.status(statusCode.CREATED).send(response);
+    return res.status(statusCode.CREATED).send(statusCode.CREATED, response);
   }
 
   @Post('/recording/delete')

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -35,6 +35,7 @@ import {
 import axios from 'axios';
 import { RecordingDto } from './dto/recording.dto';
 import { RecordingRepository } from './repository/recording.repository';
+import { statusCode } from "../modules/response/response.status.code";
 
 const FormData = require('form-data');
 
@@ -360,7 +361,7 @@ export class ScriptService {
 
     if (!script) {
       return {
-        status: 400,
+        status: statusCode.NOT_FOUND,
         message: 'There is no script with this id',
       };
     }
@@ -382,13 +383,6 @@ export class ScriptService {
       recordingDtoLength,
     );
 
-    // recordingDto.name = name;
-    // recordingDto.link = response.data['url'];
-    // recordingDto.endTime = endtime;
-    // recordingDto.isDeleted = false;
-    // recordingDto.date = date;
-    // recordingDto.script = script;
-
     // change recordingDto to JSON
     const recordingDtoJson = JSON.stringify(recordingDto);
     console.log('recordingDtoJson >>>>>>>>>>>>> ', recordingDtoJson);
@@ -396,6 +390,8 @@ export class ScriptService {
 
     // save script
     await script.save();
+
+    console.log("NAME", name);
 
     return {
       link: response.data['url'],

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -391,11 +391,9 @@ export class ScriptService {
     // save script
     await script.save();
 
-    console.log("NAME", name);
-
     return {
       link: response.data['url'],
-      name: name,
+      name: recordingDto.name,
       scriptId: scriptId,
       date: date,
     };

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -36,6 +36,7 @@ import axios from 'axios';
 import { RecordingDto } from './dto/recording.dto';
 import { RecordingRepository } from './repository/recording.repository';
 import { statusCode } from "../modules/response/response.status.code";
+import { message } from "../modules/response/response.message";
 
 const FormData = require('form-data');
 
@@ -517,7 +518,7 @@ export class ScriptService {
     if (!script) {
       return {
         status: statusCode.NOT_FOUND,
-        message: 'There is no script with this id',
+        message: message.NOT_FOUND_SCRIPT,
       };
     }
 

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -623,8 +623,7 @@ export class ScriptService {
     });
 
     // if filteredRecording is empty or nil, return 400
-    console.log("filteredRecording >>>>>>>>>>>>> ", filteredRecording);
-    if (!filteredRecording) {
+    if (!filteredRecording || filteredRecording.length == 0) {
       return {
         message: message.NOT_FOUND_SCRIPT_OR_RECORDING,
       };

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -545,8 +545,7 @@ export class ScriptService {
     });
     if (!recording) {
       return {
-        status: 400,
-        message: 'There is no recording with this link',
+        message: message.NOT_FOUND_RECORDING,
       };
     }
     console.log('RECORDING >>>>>>>>>>>>> ', recording);

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -503,28 +503,20 @@ export class ScriptService {
     newName: string,
   ) {
     const user = await this.userRepository.findOneOrFail(userId);
-    console.log('scriptId On Recording >>>>>>>>>>>>> ', scriptId);
 
     // find script by id
     const scripts = await user.scripts;
-    console.log('USER SCRIPTS >>>>>>>>>>>>> ', scripts);
 
     let script;
     for (let i = 0; i < scripts.length; i++) {
-      console.log('SCRIPTS[i] >>>>>>>>>>>>> ', scripts[i]);
-      console.log('SCRIPTS[i].id >>>>>>>>>>>>> ', scripts[i].id);
-      console.log('scriptId >>>>>>>>>>>>> ', scriptId);
-
       if (scripts[i].id == scriptId) {
-        console.log('MATCHED SCRIPT >>>>>>>>>>>>> ', scripts[i]);
         script = scripts[i];
       }
     }
-    console.log('SELECTED SCRIPT >>>>>>>>>>>>> ', script);
 
     if (!script) {
       return {
-        status: 400,
+        status: statusCode.NOT_FOUND,
         message: 'There is no script with this id',
       };
     }

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -642,12 +642,10 @@ export class ScriptService {
 
     // find script by id
     const scripts = await user.scripts;
-    console.log('delete :: SELECTED SCRIPT >>>>>>>>>>>>> ', scripts);
 
     if (!scripts) {
       return {
-        status: 400,
-        message: 'delete :: There is no script in this user',
+        message: message.NOT_FOUND_SCRIPT,
       };
     }
 

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -623,6 +623,7 @@ export class ScriptService {
     });
 
     // if filteredRecording is empty or nil, return 400
+    console.log("filteredRecording >>>>>>>>>>>>> ", filteredRecording);
     if (!filteredRecording) {
       return {
         message: message.NOT_FOUND_SCRIPT_OR_RECORDING,

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -612,7 +612,7 @@ export class ScriptService {
     // make sure allRecording is not empty or undefined or null, if then, return 400
     if (!allRecording) {
       return {
-        message: message.NOT_FOUND_RECORDING
+        message: message.NOT_FOUND_RECORDING,
       };
     }
 
@@ -625,8 +625,7 @@ export class ScriptService {
     // if filteredRecording is empty or nil, return 400
     if (!filteredRecording) {
       return {
-        status: 400,
-        message: 'There is no recording with this scriptId',
+        message: message.NOT_FOUND_SCRIPT_OR_RECORDING,
       };
     }
 

--- a/src/script/script.service.ts
+++ b/src/script/script.service.ts
@@ -612,11 +612,11 @@ export class ScriptService {
     // make sure allRecording is not empty or undefined or null, if then, return 400
     if (!allRecording) {
       return {
-        status: 400,
-        message: 'There is no script on your user',
+        message: message.NOT_FOUND_RECORDING
       };
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const filteredRecording = allRecording?.filter((recording) => {
       return recording[0].scriptId == scriptId;


### PR DESCRIPTION
## 고친 사항
* [x] Recording RESTful API 전체에 대하여 status code를 명시적으로 반환한다.
* 이를 위하여 기존에 존재하던 `util.success` 및 `util.fail` 을 도입하였다.